### PR TITLE
fix: add OIDC permissions to Go API workflow

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -13,6 +13,10 @@ on:
     
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds explicit permissions for the Go API workflow to enable OpenID
Connect (OIDC) authentication with cloud providers. The workflow now has
read access to repository contents and write access to the ID token,
which is required for secure cloud deployments without storing long-lived
credentials.
