### PR TITLE
fix: use full ARN for AWS role assumptions on Go API

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -70,7 +70,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: ${{ secrets.AWS_REGION }}
-        role-to-assume: ${{ secrets.ROLE_TO_ASSUME_ECR }}
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.ROLE_TO_ASSUME_ECR }}
 
     - name: Login to AWS ECR
       id: login-ecr
@@ -92,7 +92,7 @@ jobs:
       id: deploy-app-runner
       uses: awslabs/amazon-app-runner-deploy@main
       with:
-        access-role-arn: ${{ secrets.ROLE_TO_ASSUME_APP }}
+        access-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.ROLE_TO_ASSUME_APP }}
         region: ${{ secrets.AWS_REGION }}
         service: ${{ vars.SERVICE_NAME }}
         image: ${{ steps.build-docker-image.outputs.image }}

--- a/go-api/example.http
+++ b/go-api/example.http
@@ -1,5 +1,5 @@
 ### Default: Hello, world!
 GET http://localhost:8080/hello HTTP/1.1
 
-### Custom name: Hello, DevOps!
-GET http://localhost:8080/hello?name=DevOps HTTP/1.1
+### Custom name: Hello, GoDev!
+GET http://localhost:8080/hello?name=GoDev HTTP/1.1


### PR DESCRIPTION
Update AWS IAM role references in GitHub workflow to use complete ARN
format instead of just role names. This change constructs the full ARN
using AWS_ACCOUNT_ID secret for both ECR authentication and App Runner
deployment steps, providing more explicit and secure role assumption.
