### PR TITLE
fix: correct GitHub OIDC condition structure

### DIFF
--- a/tf-iac/iam.tf
+++ b/tf-iac/iam.tf
@@ -80,6 +80,8 @@ resource "aws_iam_role" "ecr-role" {
         Condition = {
           StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          },
+          StringLike = {
             "token.actions.githubusercontent.com:sub" = "repo:diegomais/say-hello-cloud:*"
           }
         }


### PR DESCRIPTION
The IAM role for ECR access had an incorrect Condition structure where
the "sub" claim was incorrectly placed under StringEquals instead of
StringLike. This fix properly separates the conditions by their
appropriate operators, ensuring the GitHub Actions workflow can
successfully authenticate with AWS.
