### PR TITLE
fix: correct docker tag command syntax

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -83,7 +83,7 @@ jobs:
         TAG: ${{ steps.generate_tag.outputs.sha }}
       run: |
         docker build -t $REGISTRY/say-hello-cloud-api:$TAG .
-        docker tag -t $REGISTRY/say-hello-cloud-api:$TAG $REGISTRY/say-hello-cloud-api:latest
+        docker tag $REGISTRY/say-hello-cloud-api:$TAG $REGISTRY/say-hello-cloud-api:latest
         docker push --all-tags $REGISTRY/say-hello-cloud-api
         IMAGE=$(echo $REGISTRY/say-hello-cloud-api:$TAG)
         echo "image=$IMAGE" >> $GITHUB_OUTPUT

--- a/go-api/example.http
+++ b/go-api/example.http
@@ -3,3 +3,6 @@ GET http://localhost:8080/hello HTTP/1.1
 
 ### Custom name: Hello, GoDev!
 GET http://localhost:8080/hello?name=GoDev HTTP/1.1
+
+### Custom name: Hello, DevOps!
+GET http://localhost:8080/hello?name=DevOps HTTP/1.1


### PR DESCRIPTION
The docker tag command was incorrectly using the -t flag which
caused the workflow to fail. This removes the redundant flag as
the correct syntax is 'docker tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]'.
