### PR TITLE
fix: adjust App Runner resource allocation

### DIFF
--- a/.github/workflows/go-api.yaml
+++ b/.github/workflows/go-api.yaml
@@ -96,9 +96,9 @@ jobs:
         region: ${{ secrets.AWS_REGION }}
         service: ${{ vars.SERVICE_NAME }}
         image: ${{ steps.build-docker-image.outputs.image }}
-        cpu: 1
-        memory: 2
-        port: 3000
+        cpu: 0.25
+        memory: 0.5
+        port: 8080
         wait-for-service-stability-seconds: 180
 
     - name: App Runner check

--- a/go-api/example.http
+++ b/go-api/example.http
@@ -3,6 +3,3 @@ GET http://localhost:8080/hello HTTP/1.1
 
 ### Custom name: Hello, GoDev!
 GET http://localhost:8080/hello?name=GoDev HTTP/1.1
-
-### Custom name: Hello, DevOps!
-GET http://localhost:8080/hello?name=DevOps HTTP/1.1


### PR DESCRIPTION
Reduce CPU from 1 to 0.25 vCPU and memory from 2GB to 0.5GB to
optimize resource usage and costs. Also change the exposed port from
3000 to 8080 to match the application's actual configuration.
